### PR TITLE
change class method leaders in spec from '#' to '.'

### DIFF
--- a/spec/dog_spec.rb
+++ b/spec/dog_spec.rb
@@ -16,14 +16,14 @@ describe "Dog" do
     end
   end
 
-  describe "#clear_all" do 
+  describe ".clear_all" do 
     it "is a class method that empties the @@all array of all existing dogs" do 
       Dog.clear_all
       expect(Dog.class_variable_get(:@@all)).to match([]  )
     end
   end
 
-  describe "#all" do
+  describe ".all" do
     it "is a class method that puts out the name of each dog to the terminal" do 
       expect{Dog.all}.to output("Pluto\nFido\nMaddy\n").to_stdout
     end 


### PR DESCRIPTION
Change class method patterns in spec from `#class_method` to `.class_method` in accordance with Ruby naming conventions

<img width="697" alt="screen shot 2016-01-01 at 5 53 05 pm" src="https://cloud.githubusercontent.com/assets/10603933/12072530/8f0654aa-b0b0-11e5-8fd1-0861d45134af.png">

ref: [betterspecs.org](http://betterspecs.org/)